### PR TITLE
Generalize alternative licensing and add notice

### DIFF
--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -6,10 +6,10 @@ Copyright {{{name}}}
           Ed25519: {{{firstHalfOfKey}}}
                    {{{secondHalfOfKey}}}
 
-Source code is available at:
+Source Code:
 {{{repository}}}
 
-Alternative licenses are available at:
+Alternative Licenses:
 {{{alternativeLicenses}}}
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -27,8 +27,8 @@ are met:
     entire source code of which is not published and publicly licensed
     under licenses approved by the Open Source Initiative, must be
     limited to a period of {{{gracePeriod}}} consecutive calendar days.
-    This condition is waived if alternative licenses permitting those
-    uses cease to be available for {{{waiverPeriod}}} consecutive calendar days.
+    This condition is waived if alternative licenses cease to be
+    available for {{{waiverPeriod}}} consecutive calendar days.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT

--- a/LICENSE.mustache
+++ b/LICENSE.mustache
@@ -9,30 +9,26 @@ Copyright {{{name}}}
 Source code is available at:
 {{{repository}}}
 
+Alternative licenses are available at:
+{{{alternativeLicenses}}}
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:
 
-1.  Redistributions of source code must retain the above copyright
-    and source availability notices, this list of conditions and the
-    following disclaimer.
+1.  Redistributions of source code must retain the above notices,
+    this list of conditions and the following disclaimer.
 
-2.  Redistributions in binary form must reproduce the above copyright
-    and source availability notices, this list of conditions and the
-    following disclaimer in the documentation and/or other materials
-    provided with the distribution.
+2.  Redistributions in binary form must reproduce the above notices,
+    this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
 
 3.  Uses in the execution or development of any computer program, the
     entire source code of which is not published and publicly licensed
     under licenses approved by the Open Source Initiative, must be
-    limited to a period of {{{gracePeriod}}} consecutive calendar days. This
-    condition is waived if licenses permitting those uses cease to be
-    available via the following agent, or a successor named in a
-    subsequent release, for {{{waiverPeriod}}} consecutive calendar days:
-
-        {{{agentName}}}
-        {{{agentWebsite}}}
-        Project: {{{projectID}}}
+    limited to a period of {{{gracePeriod}}} consecutive calendar days.
+    This condition is waived if alternative licenses permitting those
+    uses cease to be available for {{{waiverPeriod}}} consecutive calendar days.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT


### PR DESCRIPTION
This pull request:

1. moves alternative licensing information to a new notice line, like the copyright and source-available notices

2. adjusts conditions 1 and 2 to require preservation of all notices, including the new alternative-licensing notice

3. generalizes the automatic waiver of condition 3 to trigger based on availability of alternative licenses generally, without mentioning an agent